### PR TITLE
allow closure types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/MYMETA.*
+/Makefile
+/blib
+/pm_to_blib
+/NativeCall-*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /blib
 /pm_to_blib
 /NativeCall-*
+*.bak

--- a/MANIFEST
+++ b/MANIFEST
@@ -4,4 +4,5 @@ Makefile.PL
 examples/troll.pl
 lib/NativeCall.pm
 t/basic.t
+t/closure.t
 t/symbol.t

--- a/lib/NativeCall.pm
+++ b/lib/NativeCall.pm
@@ -22,11 +22,11 @@ sub _attr_parse {
     (\w+)
     (?:
       \(
-      (.*?)
+      (.*)
       \)
     )?
   /x);
-  return ($attribute, [ split /,\s*/, $args//'' ]);
+  return ($attribute, [ map { s/;/,/gr; } split /,\s*/, ($args//'') =~ s/(\([^)]*\))/$1 =~ s{,}{;}rg /ger ]);
 }
 
 sub MODIFY_CODE_ATTRIBUTES {

--- a/lib/NativeCall.pm
+++ b/lib/NativeCall.pm
@@ -105,7 +105,8 @@ use what is already loaded.
 
 =item Args
 
-A comma-separated list of L<FFI::Platypus::Type>s.
+A comma-separated list of L<FFI::Platypus::Type>s.  All types are supported,
+including L<closures|FFI::Platypus::Type#Closures>.
 
 =item Returns
 

--- a/t/closure.t
+++ b/t/closure.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+use FFI::Platypus;
+
+my %args;
+
+no warnings 'redefine';
+sub FFI::Platypus::attach {
+  my($self, $name, $args, $ret) = @_;
+  $args{$name->[0]} = $args;
+  $self;
+}
+
+use parent qw( NativeCall );
+
+sub foo1 :Args((int)->int) :Returns(void) {}
+is_deeply $args{foo1}, [ '(int)->int' ];
+
+sub foo2 :Args((int)->int,int) :Returns(void) {}
+is_deeply $args{foo2}, [ '(int)->int', 'int' ];
+
+sub foo3 :Args((int,int)->int) :Returns(void) {}
+is_deeply $args{foo3}, [ '(int,int)->int' ];
+
+sub foo4 :Args((int,int)->int,int,(string,int,int)->int) :Returns(void) {}
+is_deeply $args{foo4}, [ '(int,int)->int', 'int', '(string,int,int)->int' ];
+
+done_testing;


### PR DESCRIPTION
This lets you use closure types which look something like this:  `(int)->int` or `(int,int)->int`.