### PR TITLE
require 5.16.0

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 my %runtime_reqs = (
+  'perl' => '5.016',
   'parent' => 0,
   'FFI::Platypus' => 0,
   'FFI::CheckLib' => 0.06,

--- a/lib/NativeCall.pm
+++ b/lib/NativeCall.pm
@@ -2,6 +2,7 @@ package NativeCall;
 
 use strict;
 use warnings;
+use 5.016;
 use Sub::Util qw(subname);
 use FFI::Platypus;
 use FFI::CheckLib 0.06;


### PR DESCRIPTION
I did some debugging on the errors seen here:

http://matrix.cpantesters.org/?dist=NativeCall+0.004

for Perl 5.14.x and earlier, and it looks like the bug is actually in `attributes.pm`, which is not distributed on CPAN independently of perl, and not something that can be worked around.  I suggest just not supporting 5.14 or earlier is the appropriate thing to do here in 2016.