### PR TITLE
use strcmp to do basic test instead of fmax

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -1,8 +1,9 @@
 use strict;
 use warnings;
-use Test::More tests => 1;
+use Test::More tests => 2;
 
 use parent qw(NativeCall);
 
-sub fmax :Args(double, double) :Native :Returns(double) {}
-is fmax(2.0, 3.0), 3.0;
+sub strcmp :Args(string,string) :Native :Returns(int) {}
+is strcmp("abc","abc"), 0;
+isnt strcmp("abc","def"), 0;


### PR DESCRIPTION
Since fmax may be in the math library.  Specifically this test didn't work on Straberry Perl because fmax could not be found.  strcmp should be safer.